### PR TITLE
fixed meta version issue with flutter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.2+1
+- Fixed issue on **meta**
+    - downgraded **meta** to 1.3.0 for compatibility with flutter
+
 ## 0.0.2+0
 - Added Postorized **(experimental)**
 - Added HTTP error code transformer

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: postor
 description: A wrapper around Dart's http package, which supports Manageable Requests Cancellation, Request Policy (Timeout and Retry), Easier Multipart Requests, etc.
-version: 0.0.2+0
+version: 0.0.2+1
 repository: https://www.github.com/iandis/postor
 issue_tracker: https://www.github.com/iandis/postor/issues
 
@@ -10,7 +10,7 @@ environment:
 dependencies:
   ctmanager: ^0.0.1+2
   http: ^0.13.3
-  meta: ^1.7.0
+  meta: ^1.3.0
   path: ^1.8.0
   retry: ^3.1.0
 


### PR DESCRIPTION
currently flutter still depends on **meta** 1.3.0, while postor depends on 1.7.0. 
so it needs to be downgraded. 